### PR TITLE
added the date when staking warp is going to be available

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -22,8 +22,11 @@ You can find the application here: [YieldWard homepage](https://yieldward.com).
 - Maximize their yield potential
 - Repay future loans seamlessly
 
-
 At the [Warden Protocol](https://wardenprotocol.org) mainnet launch, you'll benefit from 1:1 [WARD](https://docs.wardenprotocol.org/tokens/ward-token/ward) airdrop at Warden Protocol's mainnet launch.
+
+:::tip
+Staking WARP will be available in the **middle of August 2024**.
+:::
 
 ## Get started
 

--- a/docs/stake.md
+++ b/docs/stake.md
@@ -40,6 +40,6 @@ That's it! Now you can check the details of your stake and stake more, as explai
 
 ## Stake WARP
 
-Later you'll be able to stake Warden's [WARP token](https://docs.wardenprotocol.org/tokens/warp-token/warp) to get more WARP from the 1:1.2 airdrop at the [Warden Protocol](https://wardenprotocol.org) mainnet launch.
+Starting from the **middle of August 2024**, you'll be able to stake Warden's [WARP token](https://docs.wardenprotocol.org/tokens/warp-token/warp). It'll allow you to get more WARP from the 1:1.2 airdrop at the [Warden Protocol](https://wardenprotocol.org) mainnet launch.
 
 Stay tuned!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated documentation to include specific timelines for staking WARP tokens, with staking beginning in mid-August 2024.
	- Added an informational tip in the introduction regarding the upcoming staking availability, enhancing user engagement and planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->